### PR TITLE
Only run 'Lint: json files' for changed .json files AND when it is a …

### DIFF
--- a/.github/workflows/build-test-measure.yml
+++ b/.github/workflows/build-test-measure.yml
@@ -54,7 +54,9 @@ jobs:
   lint-json:
     name: 'Lint: .json files'
     needs: pre-run
-    if: needs.pre-run.outputs.changed-json == 'true'
+    # only run for changed .json files AND when it is a pull_request
+    # because 'github.base_ref' will not be available on push
+    if: needs.pre-run.outputs.changed-json == 'true' && github.base_ref	== null
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
…pull_request, because 'github.base_ref' will not be available on push