### PR TITLE
Update Plugin Check action name

### DIFF
--- a/.github/workflows/wp-plugin-checks.yml
+++ b/.github/workflows/wp-plugin-checks.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run plugin check
-      uses: swissspidy/wp-plugin-check-action@v1
+      uses: wordpress/plugin-check-action@v1
       with:
         # Personal access token (PAT) used to comment on pull requests.
         # Not currently used.


### PR DESCRIPTION
## *What has changed?*:

The Plugin Check GitHub action is now part of the WordPress organization, this change reflects that.

## *Why was it needed?*:

## *How was it done?*:

## Links to trello Tickets or github issues: 

* 

---

### Code Checklist
- [x] tested
- [x] documented
