### PR TITLE
Prevent triggering wp-plugin-checks on every push and pr

### DIFF
--- a/.github/workflows/wp-plugin-checks.yml
+++ b/.github/workflows/wp-plugin-checks.yml
@@ -2,11 +2,7 @@ name: 'WordPress plugin checks'
 
 on:
   workflow_call:
-  pull_request:
-  push:
-    branches:
-    - main
-    - 'releases/*'
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## *What has changed?*:

## *Why was it needed?*:

## *How was it done?*:

## Links to trello Tickets or github issues: 

* 

---

### Code Checklist
- [ ] tested
- [ ] documented
